### PR TITLE
lift_novalue: always returns unaltered monad [time 04:36]

### DIFF
--- a/monad.js
+++ b/monad.js
@@ -115,6 +115,16 @@ function MONAD(modifier) {
         };
         return unit;
     };
+    unit.lift_novalue = function (name, func) {
+
+// Add a method to the prototype that calls bind with the func,
+// ignoring the return value and returning the existing monad.
+        
+        prototype[name] = function () {
+            return this.bind(func, arguments), this.bind(unit);
+        };
+        return unit;
+    };
     return unit;
 }
 


### PR DESCRIPTION
The commit line should read: "always returns **monad**"

I didn't mean to imply that it was somehow immutable, merely that a monad would always be returned.

There may be an obvious solution that I missed, and I can't say I like how I've implemented this function, it seems inefficient somehow.

Perhaps one is supposed to create a function that is assured of returning the monad, although that may not be convenient if one is uplifting existing external functions.

Advise appreciated.